### PR TITLE
fix: add types to cjs export

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "build/cjs/index.js",
   "module": "build/esm/index.js",
   "browser": "build/esm/index.js",
-  "types": "build/esm/index.d.ts",
   "exports": {
     "./node": "./build/cjs/node/node.js",
     "./src/node": "./build/cjs/node/node.js",

--- a/scripts/fixTypes.ts
+++ b/scripts/fixTypes.ts
@@ -1,7 +1,7 @@
 import { glob } from 'glob'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { writeFile, rename } from 'node:fs/promises'
+import { writeFile, rename, copyFile } from 'node:fs/promises'
 
 const GlobJSExts = [`d.ts`, `d.ts.map`]
 const exts = GlobJSExts.join(`,`)
@@ -9,8 +9,11 @@ const GlobJSFiles = `**/*.{${exts}}`
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 const rootDir = path.join(dirname, `../`)
+const typesDir = path.join(rootDir, `./build/types`)
 const esmDir = path.join(rootDir, `./build/esm`)
-const typeIdx = path.join(esmDir, `index.d.ts`)
+const esmIdx = path.join(esmDir, `index.d.ts`)
+const cjsDir = path.join(rootDir, `./build/cjs`)
+const cjsIdx = path.join(cjsDir, `index.d.ts`)
 
 export const getTypes = async () => {
   return await glob(GlobJSFiles, {
@@ -20,17 +23,34 @@ export const getTypes = async () => {
     ignore: [`**/*.js`, `**/node/**`],
   })
 }
-;(async () => {
+
+const copyType = async (loc:string) => {
+  const name = path.basename(loc)
+  const esmLoc = path.resolve(esmDir, name)
+  await rename(loc, esmLoc)
+
+  const cjsLoc = path.resolve(cjsDir, name)
+  await copyFile(esmLoc, cjsLoc)
+}
+
+const generateIndexes = async () => {
   const typeFiles = await getTypes()
   const typeItems: string[] = []
   await Promise.all(
     typeFiles.map(async loc => {
-      await rename(loc, path.resolve(esmDir, path.basename(loc)))
-      if (loc.endsWith(`d.ts.map`) || loc.includes(`index.d`)) return
+      const isIdx = loc.includes(`index.d`)
+      
+      !isIdx && await copyType(loc)
+
+      if (loc.endsWith(`d.ts.map`) || isIdx) return
 
       typeItems.push(`export * from "./${path.basename(loc, `.d.ts`)}"`)
     })
   )
 
-  await writeFile(typeIdx, typeItems.join(`\n`))
-})()
+  const joined = typeItems.join(`\n`)
+  await writeFile(esmIdx, joined)
+  await writeFile(cjsIdx, joined)
+}
+
+;(async () => await generateIndexes())()

--- a/src/array/isArr.ts
+++ b/src/array/isArr.ts
@@ -9,4 +9,4 @@
  * @param {any} value - value to be check if is an array
  * @return {Boolean} - T/F value is an array
  */
-export const isArr = <T = any[]>(value: any): value is T => Array.isArray(value)
+export const isArr = <T extends Array<any> = any>(value: any): value is T[] => Array.isArray(value)

--- a/src/method/checkCall.ts
+++ b/src/method/checkCall.ts
@@ -21,6 +21,10 @@ export function checkCall<T = any>(
   method: <M = any>(...params: any[]) => M,
   ...params: any[]
 ): T
+export function checkCall<T = any, M = any>(
+  method: (...params: any[]) => M,
+  ...params: any[]
+): T
 export function checkCall<T = any>(
   method: (...params: any[]) => any,
   ...params: any[]

--- a/src/method/doIt.ts
+++ b/src/method/doIt.ts
@@ -34,10 +34,10 @@ export function doIt<
 export function doIt<
   F extends (...params: any[]) => any = (...params: any[]) => any
 >(last: F, bindTo: any, num: number): ReturnType<F>[]
-
 export function doIt<
   F extends (...params: any[]) => any = (...params: any[]) => any
->(...args: Array<F | any | number>) {
+>(...args: Array<F | any | number>): ReturnType<F>[]
+export function doIt(...args: Array<any>) {
   const params = args.slice()
 
   const num = params.find(p => isNum(p))

--- a/src/method/limbo.ts
+++ b/src/method/limbo.ts
@@ -29,11 +29,15 @@ export function limbo<T = any>(
   promise: Promise<any>,
   asObj?: boolean
 ): Promise<[err?: Error, response?: T]>
+export function limbo<T = any, E = Error>(
+  promise: Promise<any>,
+  asObj?: boolean
+): Promise<[err?: E, response?: T]>
 export function limbo(
   promise: Promise<any>,
   asObj?: boolean
 ): Promise<[err?: Error, response?: any]>
-export function limbo<T = any, E = Error>(
+export function limbo<T=any, E=Error>(
   promise: Promise<any>,
   asObj: boolean = false
 ): Promise<[err?: E, response?: T]> {


### PR DESCRIPTION
## Updates

* Include types files in cjs export
* Remove "types" from `pacakge.json`
  * Does not seem to work regardless of the settings
  * May be able to add it back at somepoint
  * As a work-around, including the types in both the esm and cjs export looks to be working. 

